### PR TITLE
_market_data append的内容，增加 deepcopy处理，

### DIFF
--- a/QAStrategy/qactabase.py
+++ b/QAStrategy/qactabase.py
@@ -203,7 +203,7 @@ class QAStrategyCTABase():
                 print('backtest: Settle!')
                 self.acc.settle()
         self._on_1min_bar()
-        self._market_data.append(item)
+        self._market_data.append(copy.deepcopy(item))
         self.running_time = str(item.name[0])
         self.on_bar(item)
 
@@ -232,7 +232,7 @@ class QAStrategyCTABase():
                     print('backtest: Settle!')
                     self.acc.settle()
             self._on_1min_bar()
-            self._market_data.append(item)
+            self._market_data.append(copy.deepcopy(item))
             self.running_time = str(item.name[0])
             self.on_bar(item)
 
@@ -260,7 +260,7 @@ class QAStrategyCTABase():
                 self.on_dailyclose()
                 self.on_dailyopen()
             self._on_1min_bar()
-            self._market_data.append(item)
+            self._market_data.append(copy.deepcopy(item))
             self.running_time = str(item.name[0])
             self.on_bar(item)
 
@@ -288,7 +288,7 @@ class QAStrategyCTABase():
                 self.on_dailyclose()
                 self.on_dailyopen()
             self._on_1min_bar()
-            self._market_data.append(item)
+            self._market_data.append(copy.deepcopy(item))
             self.running_time = str(item.name[0])
             self.on_bar(item)
 


### PR DESCRIPTION
python3.6.5， 发现market data 内容全是一样的，总是新内容顶替掉所有的历史。故在所有append的地方加了深拷贝。